### PR TITLE
fix(pipelines-commin): Catch empty table error

### DIFF
--- a/pipelines/pipelines-common/src/pipelines_common/cli.py
+++ b/pipelines/pipelines-common/src/pipelines_common/cli.py
@@ -86,7 +86,9 @@ def cli_main(
         destination=args.destination,
         progress=args.progress,
     )
-    LOGGER.info(f"-- Running pipeline={pipeline.pipeline_name} --")
+    LOGGER.info(f"-- Starting pipeline={pipeline.pipeline_name} --")
+    LOGGER.info("Dropping pending packages to ensure a clean new load")
+    pipeline.drop_pending_packages()
     pipeline.run(
         data,
         loader_file_format=args.loader_file_format,


### PR DESCRIPTION
### Summary

If a table was created in the catalog but the data failed to load then the next time the pipeline ran an
error would occur trying to access the `_dlt` tables as they were not catching an `IndexError`

We also ensure that the pipeline drops pending packages before running so we are always pulling from the sources.