### PR TITLE
chore(pipelines-common): Run e2e tests on push/pr

### DIFF
--- a/.github/workflows/pipelines-common_e2e_tests.yml
+++ b/.github/workflows/pipelines-common_e2e_tests.yml
@@ -1,15 +1,22 @@
 name: End-to-end tests for pipelines-common package
 on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "infra/local/**"
+      - "pipelines/pipelines-common/**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "infra/local/**"
+      - "pipelines/pipelines-common/**"
   workflow_dispatch:
     inputs:
       ref:
         description: "The branch or tag to checkout"
         required: false
         default: ""
-  workflow_run:
-    workflows: ["Unit tests for pipelines-common package"]
-    types:
-      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -19,19 +26,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       # ----------- Checkout -----------
+      - name: Checkout using push or pull_request event
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/checkout@v4
       - name: Checkout using ref (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.ref != ''
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
-      - name: Checkout using ref (workflow_run)
-        if: github.event_name == 'workflow_run'
-        uses: actions/checkout@v4.2.2
-        with:
-          ref: ${{ github.ref }}
       # --------------------------------
 
       - name: Start fresh Lakekeeper instance

--- a/.github/workflows/pipelines-common_unit_tests.yml
+++ b/.github/workflows/pipelines-common_unit_tests.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       # ----------- Checkout -----------
-      - name: Checkout for push or pull_request event
+      - name: Checkout using push or pull_request event
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         uses: actions/checkout@v4
       - name: Checkout using ref (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.ref != ''
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
       # --------------------------------


### PR DESCRIPTION
### Summary

The commit status does not get set for a workflow_run trigger and it's more confusing to understand
what the actual status of the tests is.

