### PR TITLE
fix(pipelines); Don't force a replace write-disposition in dlt scripts

### DIFF
--- a/infra/ansible/playbooks/ingestion/templates/cron/elt_task.sh.j2
+++ b/infra/ansible/playbooks/ingestion/templates/cron/elt_task.sh.j2
@@ -43,8 +43,7 @@ uv run \
   --refresh \
   --script $EXTRACT_AND_LOAD_SCRIPT \
   --log-level $LOG_LEVEL \
-  --on-pipeline-step-failure $ON_PIPELINE_FAILURE \
-  --write-disposition replace
+  --on-pipeline-step-failure $ON_PIPELINE_FAILURE
 
 # Transform
 if [ -n "$dbt_project_dir" ]; then


### PR DESCRIPTION
### Summary

Each script has its own defaults, allow them to take over
