### PR TITLE
fix(pipelines): Specify partitioning correctly for trino adapter.

### DIFF
--- a/pipelines/modelling/isis/models/accelerator/mcr_equipment_downtime_records.sql
+++ b/pipelines/modelling/isis/models/accelerator/mcr_equipment_downtime_records.sql
@@ -1,6 +1,11 @@
-{{ config(
-    partition_by=["cycle_name"]
-) }}
+{{
+  config(
+    properties={
+      "partitioning": "ARRAY['cycle_name']",
+    },
+    on_table_exists = 'drop'
+)
+}}
 {% set MCR_LOGBOOK = dbt.string_literal("MCR Running Log") %}
 {% set OPRALOG_EPOCH = dbt.string_literal('2017-04-25') %} -- Opralog started being used from cycle 2017/01
 

--- a/pipelines/modelling/isis/models/facility/cycles.sql
+++ b/pipelines/modelling/isis/models/facility/cycles.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    on_table_exists = 'drop'
+)
+}}
+
 with
 
 staging as (


### PR DESCRIPTION
### Summary

The Trino adapter for dbt requires a different method of specifying partitioning: https://docs.getdbt.com/reference/resource-configs/trino-configs#file-format-configuration. Fix this on our models.

Also, configure models to drop and create a new tables otherwise we seem to be left with object files in S3 with `dbt_tmp` in the names and this looks confusing.

