### PR TITLE
fix(ansible): Force reinstall of all packages for extract and load step

### DIFF
--- a/infra/ansible/playbooks/ingestion/templates/cron/elt_task.sh.j2
+++ b/infra/ansible/playbooks/ingestion/templates/cron/elt_task.sh.j2
@@ -40,7 +40,7 @@ ensure_elt_sources_exist
 # Extraction
 cd $ELT_GIT_DEST/$extract_and_load_dir
 uv run \
-  --refresh \
+  --reinstall \
   --script $EXTRACT_AND_LOAD_SCRIPT \
   --log-level $LOG_LEVEL \
   --on-pipeline-step-failure $ON_PIPELINE_FAILURE


### PR DESCRIPTION
### Summary

`uv` caches environments when running with `--script` and won't pick up changes for editable packages where the version isn't changing.