### PR TITLE
feat(pipelines): Add cycle_interval_type column to mcr_downtime_records table

### DIFF
--- a/pipelines/modelling/isis/models/accelerator/mcr_equipment_downtime_records.sql
+++ b/pipelines/modelling/isis/models/accelerator/mcr_equipment_downtime_records.sql
@@ -115,7 +115,16 @@ downtime_records_with_cycle as (
       where
         d.fault_occurred_at >= r.started_at
         and d.fault_occurred_at <= r.ended_at
-    ) as cycle_interval,
+    ) as cycle_interval_label,
+    (
+      select
+        {{ dbt.any_value("r.type") }}
+      from
+        {{ ref('cycles') }} r
+      where
+        d.fault_occurred_at >= r.started_at
+        and d.fault_occurred_at <= r.ended_at
+    ) as cycle_interval_type,
     d.downtime_mins,
     d.fault_occurred_at,
     d.{{ identifier("group") }},


### PR DESCRIPTION
### Summary

Alter mcr_downtime_records table:

  - add cycle_interval_type column to mcr_downtime_records table.
  - rename cycle_interval to cycle_interval_label.
