### PR TITLE
Fix database name in dbt profile after catalog rename

### DIFF
--- a/infra/ansible/playbooks/ingestion/templates/dbt/profiles.yml.j2
+++ b/infra/ansible/playbooks/ingestion/templates/dbt/profiles.yml.j2
@@ -9,5 +9,5 @@ isis_catalog:
       host: {{ top_level_domain }}
       port: {{ trino_https_port }}
       http_scheme: https
-      database: isis_lakekeeper
+      database: {{ lakekeeper_catalog.name }}
       schema: analytics


### PR DESCRIPTION
### Summary

Use Ansible Jinja template to populate the dbt profile with the correct catalog name.