### PR TITLE
fix(superset): Remove spaces from role names

### DIFF
--- a/infra/ansible/roles/superset/files/docker/pythonpath/superset_config.py
+++ b/infra/ansible/roles/superset/files/docker/pythonpath/superset_config.py
@@ -108,8 +108,8 @@ AUTH_USER_REGISTRATION = True
 AUTH_ROLES_SYNC_AT_LOGIN = True
 AUTH_USER_REGISTRATION_ROLE_NAMES = [
     "Gamma",
-    "can read schema isis.analytics_facility",
-    "can read schema isis.analytics_accelerator",
+    "can_read_schema__isis.analytics_facility",
+    "can_read_schema__isis.analytics_accelerator",
     "sql_lab",
 ]
 AUTH_LDAP_FIRSTNAME_FIELD = "givenName"


### PR DESCRIPTION
### Summary

If the role names have spaces then a new user finds the following error:

```
Error adding new user to database. Can't flush None value found in collection User.roles
```

