### PR TITLE
Upgrade lakekeeper to v0.9.1

### DIFF
--- a/infra/ansible/group_vars/all/lakekeeper.yml
+++ b/infra/ansible/group_vars/all/lakekeeper.yml
@@ -1,5 +1,5 @@
 ---
-lakekeeper_image: quay.io/lakekeeper/catalog:v0.8.4
+lakekeeper_image: quay.io/lakekeeper/catalog:v0.9.1
 lakekeeper_container_network: lakekeeper
 lakekeeper_http_port: 8181
 lakekeeper_base_path: /iceberg

--- a/infra/ansible/roles/lakekeeper/tasks/main.yml
+++ b/infra/ansible/roles/lakekeeper/tasks/main.yml
@@ -25,9 +25,9 @@
       LAKEKEEPER__PG_DATABASE_URL_READ="postgresql://{{ lakekeeper_store_user }}:{{ lakekeeper_store_passwd }}@postgres:5432/{{ lakekeeper_store_dbname }}"
       LAKEKEEPER__PG_DATABASE_URL_WRITE="postgresql://{{ lakekeeper_store_user }}:{{ lakekeeper_store_passwd }}@postgres:5432/{{ lakekeeper_store_dbname }}"
       LAKEKEEPER__OPENID_PROVIDER_URI="http://{{ top_level_domain }}/auth/realms/isis"
-      LAKEKEEPER__OPENID_AUDIENCE=lakekeeper
-      LAKEKEEPER__UI__OPENID_CLIENT_ID=lakekeeper
-      RUST_LOG=warn,iceberg_catalog=trace,iceberg_catalog_bin=trace,iceberg_ext=trace
+      LAKEKEEPER__OPENID_AUDIENCE="lakekeeper"
+      LAKEKEEPER__UI__OPENID_CLIENT_ID="lakekeeper"
+      RUST_LOG="error"
     networks:
       - name: "{{ lakekeeper_container_network }}"
     comparisons:
@@ -48,8 +48,6 @@
       - "{{ lakekeeper_http_port }}:8181"
     env:
       #
-      LAKEKEEPER__BASE_URI="https://{{ top_level_domain }}{{ lakekeeper_base_path }}"
-      LAKEKEEPER__UI__LAKEKEEPER_URL="https://{{ top_level_domain }}{{ lakekeeper_base_path }}"
       LAKEKEEPER__PG_ENCRYPTION_KEY="{{ lakekeeper_store_encryption_key }}"
       LAKEKEEPER__PG_DATABASE_URL_READ="postgresql://{{ lakekeeper_store_user }}:{{ lakekeeper_store_passwd }}@postgres:5432/{{ lakekeeper_store_dbname }}"
       LAKEKEEPER__PG_DATABASE_URL_WRITE="postgresql://{{ lakekeeper_store_user }}:{{ lakekeeper_store_passwd }}@postgres:5432/{{ lakekeeper_store_dbname }}"
@@ -57,7 +55,7 @@
       LAKEKEEPER__OPENID_AUDIENCE="lakekeeper"
       LAKEKEEPER__UI__OPENID_CLIENT_ID="lakekeeper"
       LAKEKEEPER__UI__OPENID_PROVIDER_URI="http://{{ top_level_domain }}/auth/realms/isis"
-      RUST_LOG="info,iceberg_catalog=info,iceberg_catalog_bin=info,iceberg_ext=info"
+      RUST_LOG="error"
     networks:
       - name: "{{ lakekeeper_container_network }}"
     comparisons:


### PR DESCRIPTION
### Summary

Primarily this fixes console when deployed on a non-empty prefix path.

See [lakekeeper/releases/tag/v0.9.1](https://github.com/lakekeeper/lakekeeper/releases/tag/v0.9.1)

Fixes #72 
