### PR TITLE
feat(ansible): Switch domains to analytics.isis.cclrc.ac.uk

### DIFF
--- a/infra/ansible/group_vars/all/domains.yml
+++ b/infra/ansible/group_vars/all/domains.yml
@@ -1,2 +1,2 @@
 ---
-top_level_domain: data-accelerator.isis.cclrc.ac.uk
+top_level_domain: analytics.isis.cclrc.ac.uk

--- a/infra/ansible/roles/keycloak/tasks/main.yml
+++ b/infra/ansible/roles/keycloak/tasks/main.yml
@@ -80,7 +80,7 @@
         "--hostname=https://{{ top_level_domain }}{{ keycloak_base_path }}",
         "--proxy-headers=xforwarded",
         "--proxy-trusted-addresses={{ openstack_reverse_proxy_fip }},127.0.0.0/8",
-        "--log-level=DEBUG",
+        "--log-level=INFO",
       ]
     healthcheck:
       test: "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '200 OK'"


### PR DESCRIPTION
### Summary

The old one will continue to work for the time being as Traefik doesn't check the host header.

Refs #86 
