### PR TITLE
feat(pipelines-common): Allow resources with transformers to pass through cli_main

### DIFF
--- a/pipelines/ingest/opralogweb/extract_and_load.py
+++ b/pipelines/ingest/opralogweb/extract_and_load.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     cli_utils.cli_main(
         pipeline_name="opralogweb",
         default_destination="pipelines_common.dlt_destinations.pyiceberg",
-        data_generator=opralogwebdb,
+        data_generator=opralogwebdb(),
         dataset_name_suffix="opralogweb",
         default_write_disposition="append",
     )

--- a/pipelines/ingest/statusdisplay/extract_and_load.py
+++ b/pipelines/ingest/statusdisplay/extract_and_load.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     cli_utils.cli_main(
         pipeline_name="statusdisplay",
         default_destination="pipelines_common.dlt_destinations.pyiceberg",
-        data_generator=statusdisplay,
+        data_generator=statusdisplay(),
         dataset_name_suffix="statusdisplay",
         default_write_disposition="replace",
     )

--- a/pipelines/pipelines-common/src/pipelines_common/cli.py
+++ b/pipelines/pipelines-common/src/pipelines_common/cli.py
@@ -105,7 +105,7 @@ def cli_main(
     LOGGER.info("Dropping pending packages to ensure a clean new load")
     pipeline.drop_pending_packages()
     pipeline.run(
-        data_generator(),
+        data_generator,
         loader_file_format=args.loader_file_format,
         write_disposition=args.write_disposition,
     )


### PR DESCRIPTION
### Summary

If a dlt resource is called then piped through a transformer it can't be called again. This slight adjustment to the cli_main function requires the caller to pass the reader pipeline and cli_main uses it as is.